### PR TITLE
src_py: Fix `gtp.sh` dropping into PDB in newer versions of PyTorch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,9 +6,18 @@
 .. |copy| unicode:: 0xA9
 .. |---| unicode:: U+02014
 
+About this fork
+===============
+
+This fork of ELF makes ``scripts/elfgames/go/gtp.sh``
+work on PyTorch 1.12.0. At some point, PyTorch had a change that broke
+``gtp.sh``. Using an old version of PyTorch is not always an option, however.
+Newer GPUs require newer versions of CUDA that require new versions of PyTorch.
+
 ===
 ELF
 ===
+
 
 ELF is an Extensive, Lightweight, and Flexible platform for game research. We have used it to build our Go playing bot, `ELF OpenGo`__, which achieved a 14-0 record versus four global top-30 players in April 2018. The final score is 20-0 (each professional Go player plays 5 games).
 

--- a/README.rst
+++ b/README.rst
@@ -6,18 +6,14 @@
 .. |copy| unicode:: 0xA9
 .. |---| unicode:: U+02014
 
-About this fork
-===============
-
-This fork of ELF makes ``scripts/elfgames/go/gtp.sh``
-work on PyTorch 1.12.0. At some point, PyTorch had a change that broke
-``gtp.sh``. Using an old version of PyTorch is not always an option, however.
-Newer GPUs require newer versions of CUDA that require new versions of PyTorch.
-
 ===
 ELF
 ===
 
+**About this fork**: This fork of ELF makes ``scripts/elfgames/go/gtp.sh``
+work on PyTorch 1.12.0. At some point, PyTorch had a change that broke
+``gtp.sh``. Using an old version of PyTorch is not always an option, however.
+Newer GPUs require newer versions of CUDA that require new versions of PyTorch.
 
 ELF is an Extensive, Lightweight, and Flexible platform for game research. We have used it to build our Go playing bot, `ELF OpenGo`__, which achieved a 14-0 record versus four global top-30 players in April 2018. The final score is 20-0 (each professional Go player plays 5 games).
 

--- a/src_py/elf/utils_elf.py
+++ b/src_py/elf/utils_elf.py
@@ -206,7 +206,7 @@ class Batch:
                 bk.fill_(v)
             else:
                 try:
-                    bk[:] = v.squeeze_()
+                    bk[:] = v.squeeze()
                 except BaseException:
                     import pdb
                     pdb.set_trace()


### PR DESCRIPTION
## Context

At some point, PyTorch had a breaking change that affected `gtp.sh`. Using an old version of PyTorch is not always an option, however. E.g., if we are using A6000 GPUs, then we need CUDA 11, which requires at least PyTorch 1.7.0, which already has the breaking change.

## What broke?

If we run `gtp.sh` and invoke `genmove`, then we drop into pdb:
```
/data/dev/alphago/ELF/src_py/elf/utils_elf.py(191)copy_from()
-> for k, v in this_src.items():
(Pdb)
```
The bad line of code is `v.squeeze_()` in `utils_elf.py`:
```
(Pdb) v.squeeze_()
  *** RuntimeError: set_storage_offset is not allowed on a Tensor created from .data or .detach().
  If your intent is to change the metadata of a Tensor (such as sizes / strides / storage / storage_offset)
  without autograd tracking the change, remove the .data / .detach() call and wrap the change in a `with torch.no_grad():` block.
  For example, change:
      x.data.set_(y)
  to:
      with torch.no_grad():
          x.set_(y)

```

## Fix

Change `v.squeeze_()` to `v.squeeze()`.