### PR TITLE
src_cpp: Remove move limit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,10 +10,15 @@
 ELF
 ===
 
-**About this fork**: This fork of ELF makes ``scripts/elfgames/go/gtp.sh``
-work on PyTorch 1.12.0. At some point, PyTorch had a change that broke
-``gtp.sh``. Using an old version of PyTorch is not always an option, however.
-Newer GPUs require newer versions of CUDA that require new versions of PyTorch.
+**About this fork**: This fork of ELF has the following changes:
+
+- Makes ``scripts/elfgames/go/gtp.sh`` work on PyTorch 1.12.0. At some point,
+  PyTorch had a change that broke ``gtp.sh``. Using an old version of PyTorch is
+  not always an option, however.  Newer GPUs require newer versions of CUDA that
+  require new versions of PyTorch.
+- Removes the move limit that causes ELF to end games after 722 moves. Having a
+  move limit makes sense for training but is undesirable when playing against
+  ELF via GTP.
 
 ELF is an Extensive, Lightweight, and Flexible platform for game research. We have used it to build our Go playing bot, `ELF OpenGo`__, which achieved a 14-0 record versus four global top-30 players in April 2018. The final score is 20-0 (each professional Go player plays 5 games).
 

--- a/src_cpp/elfgames/go/base/go_common.h
+++ b/src_cpp/elfgames/go/base/go_common.h
@@ -10,6 +10,3 @@
 
 constexpr uint64_t BOARD_ACTION_PASS = BOARD_SIZE * BOARD_SIZE;
 constexpr uint64_t BOARD_NUM_ACTION = BOARD_SIZE * BOARD_SIZE + 1;
-
-// Maximum move.
-constexpr int BOARD_MAX_MOVE = BOARD_SIZE * BOARD_SIZE * 2;

--- a/src_cpp/elfgames/go/base/go_state.h
+++ b/src_cpp/elfgames/go/base/go_state.h
@@ -143,7 +143,7 @@ class GoState {
   }
 
   bool terminated() const {
-    return isTwoPass() || getPly() >= BOARD_MAX_MOVE || _check_superko();
+    return isTwoPass() || _check_superko();
   }
 
   Coord lastMove() const {

--- a/src_cpp/elfgames/go/common/game_selfplay.cc
+++ b/src_cpp/elfgames/go/common/game_selfplay.cc
@@ -296,6 +296,10 @@ void GoGameSelfPlay::act() {
         finish_game(FR_ILLEGAL);
         return;
       }
+      if (_options.move_cutoff > 0 && s.getPly() >= _options.move_cutoff) {
+        finish_game(FR_MAX_STEP);
+        return;
+      }
 
       BoardFeature bf(s);
       GoReply reply(bf);
@@ -418,9 +422,7 @@ void GoGameSelfPlay::act() {
   }
 
   if (s.terminated()) {
-    auto reason = s.isTwoPass()
-        ? FR_TWO_PASSES
-        : s.getPly() >= BOARD_MAX_MOVE ? FR_MAX_STEP : FR_ILLEGAL;
+    auto reason = s.isTwoPass() ? FR_TWO_PASSES : FR_ILLEGAL;
     finish_game(reason);
   }
 


### PR DESCRIPTION
## Description

Having a move limit makes sense for training, but we don't want to have it for playing against ELF in GTP mode for evaluation. Currently what happens is that if we exceed 722 moves when playing against ELF, ELF will automatically reject the move and end the game.

This PR crudely removes the move limit. 

(Ideally I would set the option `move_cutoff` to the previous value of the move limit, make sure `move_cutoff` is used everywhere, and just specify `--move_cutoff -1` for our evaluations. But I don't think it's worth the time for me to learn the ELF codebase well enough to make that more sophisticated change.)

## Testing

- launch ELF in GTP mode, paste a game of 1000 moves, check that no errors are printed